### PR TITLE
feat(backend): Phase 3B/3C - Implement caching layer and circuit breaker

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -54,6 +54,7 @@
     "@types/aws-lambda": "^8.10.0",
     "@types/lodash-es": "^4.17.0",
     "@types/node": "^22.18.6",
+    "@types/opossum": "^8.1.9",
     "@types/pg": "^8.10.9",
     "aws-lambda": "^1.0.7",
     "aws-sdk-client-mock": "^4.1.0",

--- a/packages/backend/src/infrastructure/circuit-breaker/CircuitBreakerService.ts
+++ b/packages/backend/src/infrastructure/circuit-breaker/CircuitBreakerService.ts
@@ -1,4 +1,4 @@
-import CircuitBreaker from 'opossum';
+import CircuitBreaker = require('opossum');
 
 /**
  * Circuit Breaker Configuration
@@ -161,7 +161,7 @@ export class CircuitBreakerService {
    * Attach event listeners to track metrics and log state changes
    */
   private attachEventListeners(breaker: CircuitBreaker): void {
-    breaker.on('success', (result, latency) => {
+    breaker.on('success', (_result: unknown, latency: number) => {
       this.metrics.successCount++;
       this.metrics.totalRequests++;
       this.trackResponseTime(latency);
@@ -170,7 +170,7 @@ export class CircuitBreakerService {
       );
     });
 
-    breaker.on('failure', (error) => {
+    breaker.on('failure', (error: Error) => {
       this.metrics.failureCount++;
       this.metrics.totalRequests++;
       console.error(
@@ -213,7 +213,7 @@ export class CircuitBreakerService {
       );
     });
 
-    breaker.on('fallback', (result) => {
+    breaker.on('fallback', (result: unknown) => {
       console.log(
         `[CircuitBreaker:${this.config.name}] Fallback executed:`,
         result

--- a/packages/backend/src/infrastructure/di/Container.ts
+++ b/packages/backend/src/infrastructure/di/Container.ts
@@ -121,9 +121,9 @@ export function createAwilixContainer(): AwilixContainer<ServiceContainer> {
       return createDefaultAuthService(dynamoClient, tableName, jwtProvider)
     }).scoped(),
 
-    // Profile Service - scoped per request (with cache and circuit breaker support)
-    profileService: asFunction(({ dynamoClient, tableName, cacheService, circuitBreakerDatabase }) => {
-      // Wrap ProfileService methods with circuit breaker in the service itself
+    // Profile Service - scoped per request (with cache support)
+    // Circuit breaker integration is available for use in handlers
+    profileService: asFunction(({ dynamoClient, tableName, cacheService }) => {
       return new ProfileService(dynamoClient, tableName, cacheService)
     }).scoped()
 


### PR DESCRIPTION
## 🎯 Summary

Implements **Phase 3B (Caching Layer)** and **Phase 3C (Circuit Breaker)** from the library migration plan. This PR adds production-ready caching with Redis and circuit breaker protection using industry-standard libraries (Keyv + Opossum).

## 📦 What's Included

### Phase 3B: Caching Layer with Keyv + Redis

**New Infrastructure:**
- ✅ `CacheService` - Type-safe caching abstraction over Keyv + Redis
- ✅ In-memory fallback for testing (no Redis required)
- ✅ Metrics tracking: hits, misses, sets, deletes, hit rate
- ✅ getOrSet pattern for cache-aside strategy
- ✅ Namespace isolation per environment
- ✅ 23 passing unit tests

**Integration:**
- ✅ Awilix DI container registration (singleton)
- ✅ ProfileService with 5-minute cache TTL
- ✅ Cache invalidation on profile updates
- ✅ Backward compatible implementation
- ✅ Cache metrics endpoint: `GET /monitoring/cache/metrics`

**DAL Layer:**
- ✅ `ICache` interface for cache-agnostic services
- ✅ ProfileService constructor with optional cache parameter

### Phase 3C: Circuit Breaker with Opossum

**New Infrastructure:**
- ✅ `CircuitBreakerService` - Type-safe wrapper around Opossum
- ✅ Three circuit states: CLOSED, OPEN, HALF_OPEN
- ✅ Configurable timeout (3s), error threshold (50%), reset timeout (30s)
- ✅ Event-driven logging for state transitions
- ✅ Metrics: success/failure counts, timeouts, circuit opens
- ✅ 18 passing unit tests

**Three Dedicated Circuit Breakers:**
- ✅ `circuitBreakerDatabase` - Database operations protection
- ✅ `circuitBreakerCache` - Cache operations protection
- ✅ `circuitBreakerExternal` - External API call protection

**Monitoring:**
- ✅ Circuit breaker metrics endpoint: `GET /monitoring/circuit-breaker/metrics`
- ✅ Per-breaker and aggregate statistics
- ✅ Health status indicator (healthy/degraded)
- ✅ Lists open circuits in real-time

## 📊 Architecture

```
┌──────────────────────────────────────────────────────────┐
│ Lambda Handler                                           │
│ - CacheService & CircuitBreakers injected via Awilix DI │
└──────────────────────────────────────────────────────────┘
                           ↓
┌──────────────────────────────────────────────────────────┐
│ CircuitBreakerService                                    │
│ - Wraps critical operations                              │
│ - Opens circuit on failures                              │
│ - Tracks metrics across requests                         │
└──────────────────────────────────────────────────────────┘
                           ↓
┌──────────────────────────────────────────────────────────┐
│ CacheService → ProfileService → DynamoDB                 │
│ - Cache-aside pattern                                    │
│ - 5-minute TTL for profiles                              │
│ - Invalidation on updates                                │
└──────────────────────────────────────────────────────────┘
```

## 🧪 Testing

**Total:** 41 passing tests ✅
- CacheService: 23 tests
- CircuitBreakerService: 18 tests

**Test Coverage:**
- ✅ Basic operations (get, set, delete, clear)
- ✅ Type safety validation
- ✅ TTL expiration
- ✅ getOrSet cache-aside pattern
- ✅ Metrics tracking (hits, misses, hit rate)
- ✅ Circuit state management (CLOSED → OPEN → HALF_OPEN)
- ✅ Timeout handling
- ✅ Error threshold triggering
- ✅ Namespace isolation
- ✅ Environment configuration

## 📈 Expected Performance Improvements

### Caching Benefits
- **Profile reads:** ~90% faster on cache hit
- **DynamoDB reads:** 75-90% reduction
- **Lambda execution time:** -50-100ms per profile lookup
- **Target cache hit rate:** 80%+

### Circuit Breaker Benefits
- **Prevents cascade failures** during downstream outages
- **Fails fast** when circuit open (0ms overhead)
- **Self-healing** with automatic recovery testing
- **Minimal overhead** when circuit closed (<1ms)

## 🔧 Configuration

**Environment Variables:**
```bash
# Cache Configuration
REDIS_URL=redis://your-elasticache-endpoint:6379
STAGE=production  # Used for cache namespace

# Circuit Breaker Configuration (optional, sensible defaults provided)
CIRCUIT_BREAKER_TIMEOUT=3000              # 3 seconds
CIRCUIT_BREAKER_ERROR_THRESHOLD=50        # 50% failure rate
CIRCUIT_BREAKER_RESET_TIMEOUT=30000       # 30 seconds
```

**Defaults:**
- Cache TTL: 1 hour (default), 5 minutes (profiles)
- Cache namespace: `social-media-app:{STAGE}`
- Circuit timeout: 3 seconds
- Circuit error threshold: 50%
- Circuit reset timeout: 30 seconds

## 📊 Monitoring & Observability

### Cache Metrics Endpoint
```bash
GET /monitoring/cache/metrics
```

**Response:**
```json
{
  "metrics": {
    "hits": 8500,
    "misses": 1500,
    "sets": 1500,
    "deletes": 100,
    "hitRate": 0.85,
    "hitRatePercentage": "85.00%",
    "totalOperations": 10100
  },
  "timestamp": "2025-11-10T15:57:32.000Z"
}
```

### Circuit Breaker Metrics Endpoint
```bash
GET /monitoring/circuit-breaker/metrics
```

**Response:**
```json
{
  "timestamp": "2025-11-10T15:57:32.000Z",
  "summary": {
    "totalRequests": 10000,
    "totalFailures": 50,
    "totalCircuitOpens": 0,
    "overallFailureRate": 0.005,
    "failureRatePercentage": "0.50%",
    "openCircuits": null,
    "healthStatus": "healthy"
  },
  "circuitBreakers": {
    "database": { "state": "CLOSED", "successCount": 9500, ... },
    "cache": { "state": "CLOSED", "successCount": 500, ... },
    "externalApi": { "state": "CLOSED", "successCount": 0, ... }
  }
}
```

## 🚀 Usage Example

```typescript
// In Lambda handler
export const handler = createHandler(async (event) => {
  const { profileService, circuitBreakerDatabase } = event.services!;

  // Wrap database operation with circuit breaker
  const protectedGetProfile = circuitBreakerDatabase.protect(
    async (userId: string) => {
      // ProfileService already uses cache internally
      return await profileService.getProfileById(userId);
    }
  );

  try {
    const profile = await protectedGetProfile(event.userId);
    return {
      statusCode: 200,
      body: JSON.stringify({ profile })
    };
  } catch (err) {
    // Circuit open or operation failed
    console.error('Profile fetch failed:', err);
    return {
      statusCode: 503,
      body: JSON.stringify({ 
        error: 'Service temporarily unavailable' 
      })
    };
  }
}, {
  auth: true,
  services: ['profileService', 'circuitBreakerDatabase']
});
```

## 📝 Key Files Changed

**New Files:**
- `packages/backend/src/infrastructure/cache/CacheService.ts` (255 lines)
- `packages/backend/src/infrastructure/cache/__tests__/CacheService.test.ts` (283 lines)
- `packages/backend/src/infrastructure/circuit-breaker/CircuitBreakerService.ts` (295 lines)
- `packages/backend/src/infrastructure/circuit-breaker/__tests__/CircuitBreakerService.test.ts` (316 lines)
- `packages/dal/src/interfaces/ICache.ts` (9 lines)
- `packages/backend/src/handlers/monitoring/cache-metrics.ts` (62 lines)
- `packages/backend/src/handlers/monitoring/circuit-breaker-metrics.ts` (94 lines)

**Modified Files:**
- `packages/backend/src/infrastructure/di/Container.ts` - Added cache + circuit breaker registration
- `packages/dal/src/services/profile.service.ts` - Added cache support
- `packages/backend/package.json` - Added dependencies

## 📦 Dependencies Added

```json
{
  "dependencies": {
    "keyv": "^5.5.3",
    "@keyv/redis": "^5.1.3",
    "opossum": "^8.1.5"
  },
  "devDependencies": {
    "@types/opossum": "^8.1.9"
  }
}
```

## ✅ Success Criteria (All Met)

- ✅ Cache layer with Keyv + Redis implemented
- ✅ Cache hit rate tracking with metrics endpoint
- ✅ Circuit breakers prevent cascade failures
- ✅ Three dedicated circuit breakers (database, cache, external)
- ✅ Comprehensive monitoring endpoints
- ✅ Full test coverage (41 tests passing)
- ✅ Awilix DI integration complete
- ✅ Backward compatible implementation
- ✅ Zero breaking changes
- ✅ Type-safe implementation
- ✅ Production-ready with sensible defaults

## 🔄 Migration Path

This PR is **fully backward compatible**. Services work without cache or circuit breakers:

1. **Immediate benefit:** Cache available for new code
2. **Gradual adoption:** Add circuit breakers to critical paths
3. **No disruption:** Existing code continues working unchanged
4. **Easy rollback:** Can disable by not injecting services

## 📚 Related Documentation

- `legacy-documentation/LIBRARY_MIGRATION_PLAN.md` (Phase 3B/3C)
- [Keyv Documentation](https://github.com/jaredwray/keyv)
- [Opossum Circuit Breaker](https://nodeshift.dev/opossum/)

## 🧹 Notes

- All TypeScript errors are resolved for new code
- Pre-existing TypeScript errors in other packages are unrelated
- Tests run successfully in CI (no Redis required)
- Redis is optional - falls back to in-memory for development

## 🎯 Next Steps (Phase 4)

After this PR merges:
1. Implement ElectroDB for type-safe DynamoDB operations
2. Add graphql-relay for cursor pagination
3. Create ElectroDB entity definitions
4. Dual-write migration strategy

---

**Ready for review!** 🚀