### PR TITLE
fix(backend): resolve ESM import error for opossum circuit breaker

### DIFF
--- a/packages/backend/src/infrastructure/circuit-breaker/CircuitBreakerService.ts
+++ b/packages/backend/src/infrastructure/circuit-breaker/CircuitBreakerService.ts
@@ -1,4 +1,7 @@
-import CircuitBreaker = require('opossum');
+import * as OpossumModule from 'opossum';
+
+// Handle both ESM and CJS module formats
+const CircuitBreaker = (OpossumModule as any).default || OpossumModule;
 
 /**
  * Circuit Breaker Configuration


### PR DESCRIPTION
Change from import assignment syntax to namespace import with default export handling to support ECMAScript module targets.

- Replace 'import CircuitBreaker = require()' with namespace import
- Handle both ESM and CJS module formats with fallback
- All 18 circuit breaker tests still passing ✅

Fixes TS1202: Import assignment cannot be used when targeting ECMAScript modules.