### PR TITLE
fix(build): clean stale tsbuildinfo files in clean scripts

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,7 @@
     "dev:local": "pnpm build && PORT=3001 node server.js",
     "start": "node server.js",
     "start:dev": "pnpm build && node server.js",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist *.tsbuildinfo",
     "test": "vitest run",
     "test:unit": "vitest run",
     "test:watch": "vitest",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -18,7 +18,7 @@
     "codegen": "graphql-codegen --config codegen.yml",
     "codegen:watch": "graphql-codegen --config codegen.yml --watch",
     "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
     "@apollo/server": "^5.0.2",


### PR DESCRIPTION
After the NodeNext migration, stale .tsbuildinfo files from incremental compilation were preventing TypeScript from emitting updated output.

This caused runtime errors where compiled files didn't exist:
- backend/dist/handlers/auth/*.js - missing
- backend/dist/local-dev/stream-processor.js - missing
- graphql-server/dist/standalone-server.js - missing

## Changes

- Updated clean scripts in backend and graphql-server packages to remove *.tsbuildinfo files along with dist directories
- Manually removed all stale .tsbuildinfo files from the repository

## Root Cause

With `incremental: true` in tsconfig.base.json, TypeScript creates .tsbuildinfo files to speed up rebuilds. When we changed all imports during the NodeNext migration, the old .tsbuildinfo files contained stale information causing TypeScript to incorrectly skip recompilation of affected files.

## Verification

✅ Backend handlers now compile correctly
✅ Stream processor compiles correctly
✅ GraphQL standalone-server compiles correctly
✅ Clean build from scratch works properly

Related: 48c3f50 (NodeNext migration completion)